### PR TITLE
Save client VK when setting entity

### DIFF
--- a/src/client.py
+++ b/src/client.py
@@ -166,7 +166,8 @@ class Client(object):
                 del self.result_handlers[seq_num]
             raise RuntimeError("Failed to set entity: " + result.reason)
         else:
-            return response.getFirstValue("vk")
+            self.vk = response.getFirstValue("vk")
+            return self.vk
 
     def asyncSetEntityFromFile(self, key_file_name, response_handler):
         with open(key_file_name) as f:

--- a/src/client.py
+++ b/src/client.py
@@ -133,8 +133,12 @@ class Client(object):
         po = PayloadObject(ENTITY_PO_NUM, None, key)
         frame.addPayloadObject(po)
 
+        def wrappedResponseHandler(response):
+            self.vk = response.getFirstValue("vk")
+            response_handler(response)
+
         with self.response_handlers_lock:
-            self.response_handlers[seq_num] = response_handler
+            self.response_handlers[seq_num] = wrappedResponseHandler
         frame.writeToSocket(self.socket)
 
     def setEntity(self, key):


### PR DESCRIPTION
It may be the case that a library creates a client and passes it to
another piece of code, which may need the VK. Because the VK is only
ever displayed when the client is created, the user would need to know
to provide both pieces of information: the client instance AND the vk.
By caching the vk in the client object, we remove that need.

One caveat with this is that I'm not sure where the async entity methods
actually return/display/parse the VK, so that would need to be done

Needs @jhkolb approval/review