### PR TITLE
Allow bosswave functions in callbacks

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="bw2python",
-    version="0.4",
+    version="0.5",
     description="Python bindings for Bosswave 2",
     author="Jack Kolb",
     author_email="jkolb@berkeley.edu",

--- a/src/client.py
+++ b/src/client.py
@@ -4,6 +4,7 @@ import os
 import socket
 import sys
 import threading
+import Queue
 
 from bwtypes import *
 
@@ -58,7 +59,10 @@ class Client(object):
                         result = BosswaveResult(from_, uri, frame.kv_pairs,
                                                 frame.routing_objects,
                                                 frame.payload_objects)
-                    message_handler(result)
+                    # Place message handler and result in message queue.
+                    # This allows callbacks to do bosswave actions (i.e. publish/subscribe)
+                    # because they now take place from another thread.
+                    self.msgq.put((message_handler, result))
                 elif list_result_handler is not None:
                     child = frame.getFirstValue("child")
                     if child is not None:
@@ -66,6 +70,13 @@ class Client(object):
                     if finished == "true":
                         list_result_handler(None)
 
+
+    # thread for executing callbacks
+    def _msgq_handler(self):
+        while True:
+            handler, item = self.msgq.get()
+            handler(item)
+            self.msgq.task_done()
 
     def __init__(self, host_name=None, port=None):
         default_host = "localhost"
@@ -89,6 +100,12 @@ class Client(object):
         self.host_name = host_name
         self.port = port
         self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+        # setup message queue for handling callbacks
+        self.msgq = Queue.Queue()
+        msgq_worker = threading.Thread(target=self._msgq_handler)
+        msgq_worker.daemon = True
+        msgq_worker.start()
 
         self.response_handlers = {}
         self.response_handlers_lock = threading.Lock()


### PR DESCRIPTION
Currently, executing a bosswave function from within a callback blocks
(such as when we want to publish a message whenever we receive a trigger
on a subscription). I think this was caused by some deadlock on
the socket to the client. To get around this, I start up a second thread
and have the callbacks executed there. Done some basic testing and this
seems to work fine